### PR TITLE
Add order

### DIFF
--- a/GraphQL.Tests/BaseTests.cs
+++ b/GraphQL.Tests/BaseTests.cs
@@ -10,6 +10,7 @@ using WeDoTakeawayAPI.GraphQL.Item;
 using WeDoTakeawayAPI.GraphQL.Menu;
 using WeDoTakeawayAPI.GraphQL.Menu.DataLoaders;
 using WeDoTakeawayAPI.GraphQL.Model;
+using WeDoTakeawayAPI.GraphQL.Order;
 using WeDoTakeawayAPI.GraphQL.Section;
 using WeDoTakeawayAPI.GraphQL.Section.DataLoaders;
 
@@ -38,15 +39,18 @@ namespace WeDoTakeawayAPI.GraphQL.Tests
                     .AddTypeExtension<BasketQueries>()
                     .AddTypeExtension<ItemQueries>()
                     .AddTypeExtension<MenuQueries>()
+                    .AddTypeExtension<OrderQueries>()
                     .AddTypeExtension<SectionQueries>()
                 .AddMutationType(d => d.Name("Mutation"))
                     .AddTypeExtension<AddBasketItemMutations>()
                     .AddTypeExtension<ClearBasketMutations>()
                     .AddTypeExtension<RemoveBasketItemMutations>()
                     .AddTypeExtension<UpdateBasketItemMutations>()
+                    .AddTypeExtension<AddOrderMutation>()
                 .AddType<BasketType>()
                 .AddType<ItemType>()
                 .AddType<MenuType>()
+                .AddType<OrderType>()
                 .AddType<SectionType>()
                 .AddDataLoader<IngredientByIdDataLoader>()
                 .AddDataLoader<ItemByIdDataLoader>()
@@ -55,18 +59,18 @@ namespace WeDoTakeawayAPI.GraphQL.Tests
                 .Services
                 .BuildServiceProvider();
 
-            using var scope = ServiceProvider.CreateScope();
-            var factory = scope.ServiceProvider.GetService<IDbContextFactory<ApplicationDbContext>>();
+            using IServiceScope scope = ServiceProvider.CreateScope();
+            IDbContextFactory<ApplicationDbContext> factory = scope.ServiceProvider.GetService<IDbContextFactory<ApplicationDbContext>>();
             if (factory == null) return;
-            using var dbContext = factory.CreateDbContext();
+            using ApplicationDbContext dbContext = factory.CreateDbContext();
             dbContext.Database.Migrate();
         }
 
         protected ApplicationDbContext GetDbContext()
         {
-            using var scope = ServiceProvider.CreateScope();
-            var factory = scope.ServiceProvider.GetService<IDbContextFactory<ApplicationDbContext>>();
-            var dbContext = factory?.CreateDbContext();
+            using IServiceScope scope = ServiceProvider.CreateScope();
+            IDbContextFactory<ApplicationDbContext> factory = scope.ServiceProvider.GetService<IDbContextFactory<ApplicationDbContext>>();
+            ApplicationDbContext dbContext = factory?.CreateDbContext();
             return dbContext;
         }
     }

--- a/GraphQL.Tests/Orders/AddOrderMutationTests.cs
+++ b/GraphQL.Tests/Orders/AddOrderMutationTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Threading.Tasks;
+using HotChocolate;
+using HotChocolate.Execution;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using WeDoTakeawayAPI.GraphQL.Model;
+using WeDoTakeawayAPI.GraphQL.Order;
+using Xunit;
+
+namespace WeDoTakeawayAPI.GraphQL.Tests.Orders
+{
+    public class AddOrderMutationTests : BaseTests
+    {
+        private async Task<dynamic> AddOrderForItem(IEnumerable<Guid> itemIds, int quantity = 1)
+        {
+            var items = itemIds.Select(itemId => new OrderItemInput(itemId, quantity)).ToList();
+
+            var addOrderInput = new AddOrderInput(
+                "Fred",
+                "Address1",
+                "Address2",
+                "Town",
+                "Postcode",
+                "1234",
+                "Fred@fred.com",
+                "Under the mat",
+                Guid.NewGuid(),
+                items
+            );
+
+
+            IExecutionResult result = await ServiceProvider.ExecuteRequestAsync(
+                QueryRequestBuilder
+                    .New()
+                    .SetQuery(@"
+                        mutation AddOrder($input: AddOrderInput!) {
+                          addOrder(input: $input) {
+                            order {
+                              id
+                              createdAt
+                            }
+                            errors {
+                              code
+                              message
+                            }
+                          }
+                        }
+                    ")
+                    .SetVariableValue(name: "input", value: addOrderInput)
+                    .Create()
+            );
+
+            var json = await result.ToJsonAsync();
+
+            Assert.NotNull(json);
+
+            ExpandoObject response = JsonConvert.DeserializeObject<ExpandoObject>(json, new ExpandoObjectConverter());
+
+            Assert.NotNull(response);
+
+            return response;
+        }
+
+        [Fact]
+        public async Task Add_Two_Valid_Items()
+        {
+            ApplicationDbContext dbContext = GetDbContext();
+
+            var itemIds = new List<Guid>
+            {
+                Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA4"),
+                Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA5")
+            };
+            dynamic response = await AddOrderForItem(itemIds);
+
+            // Make sure there were no errors
+            Assert.Null(response.data.addOrder.errors);
+
+            // Check the response includes an order id
+            Assert.True(Guid.TryParse(response.data.addOrder.order.id as string, out _));
+            var orderId = Guid.Parse(response.data.addOrder.order.id as string ?? string.Empty);
+
+            // Fetch the order created in the database
+            Model.Order order = await dbContext.Orders
+                .Where(o => o.Id == orderId)
+                .Include(o => o.OrderItems)
+                .FirstOrDefaultAsync();
+
+            Assert.NotNull(order);
+
+            Assert.Equal(2, order.OrderItems.Count);
+
+            OrderItem firstItem = order.OrderItems.First();
+
+            Assert.Equal("Plate of sausages", firstItem.Name);
+            Assert.Equal("Big bowl of sausages", firstItem.Description);
+            Assert.Equal(Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA4"), firstItem.ItemId);
+            Assert.Equal(1, firstItem.Quantity);
+
+            // Check that the second item was correctly added
+            OrderItem secondItem = order.OrderItems.ElementAt(1);
+
+            Assert.Equal("Chocolate ice-cream surprise", secondItem.Name);
+            Assert.Equal("An amazing mixture of chocolate and cherries", secondItem.Description);
+            Assert.Equal(Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA5"), secondItem.ItemId);
+            Assert.Equal(1, secondItem.Quantity);
+        }
+
+        [Fact]
+        public async Task Add_Invalid_Item_Id()
+        {
+            var itemIds = new List<Guid>
+            {
+                Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA4"),
+                Guid.Parse("700DCA30-C6E2-4035-AD15-783C122D6EA4")
+            };
+            dynamic response = await AddOrderForItem(itemIds);
+
+            // Look for the error
+            Assert.NotNull(response.data.addOrder.errors);
+            Assert.Equal("1012", response.data.addOrder.errors[0].code);
+            Assert.Equal("Invalid order item id", response.data.addOrder.errors[0].message);
+        }
+
+        [Fact]
+        public async Task Add_Too_Few_Items()
+        {
+            var itemIds = new List<Guid>
+            {
+                Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA4"),
+            };
+            dynamic response = await AddOrderForItem(itemIds, 0);
+
+            // Look for the error
+            Assert.NotNull(response.data.addOrder.errors);
+            Assert.Equal("1011", response.data.addOrder.errors[0].code);
+            Assert.Equal("Invalid order item quantity", response.data.addOrder.errors[0].message);
+        }
+
+        [Fact]
+        public async Task Add_Too_Many_Items()
+        {
+            var itemIds = new List<Guid>
+            {
+                Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA4"),
+            };
+            dynamic response = await AddOrderForItem(itemIds, 102);
+
+            // Look for the error
+            Assert.NotNull(response.data.addOrder.errors);
+            Assert.Equal("1011", response.data.addOrder.errors[0].code);
+            Assert.Equal("Invalid order item quantity", response.data.addOrder.errors[0].message);
+        }
+
+        [Fact]
+        public async Task Add_Too_Empty_Item_Array()
+        {
+            dynamic response = await AddOrderForItem(new List<Guid>());
+
+            // Look for the error
+            Assert.NotNull(response.data.addOrder.errors);
+            Assert.Equal("1010", response.data.addOrder.errors[0].code);
+            Assert.Equal("No items to order", response.data.addOrder.errors[0].message);
+        }
+    }
+}

--- a/GraphQL.Tests/Orders/OrderQueriesTests.cs
+++ b/GraphQL.Tests/Orders/OrderQueriesTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading.Tasks;
+using HotChocolate.Execution;
+using Snapshooter.Xunit;
+using WeDoTakeawayAPI.GraphQL.Model;
+using Xunit;
+
+namespace WeDoTakeawayAPI.GraphQL.Tests.Orders
+{
+    public class OrderQueriesTests: BaseTests
+    {
+        private async Task<Model.Order> CreateOrder()
+        {
+            ApplicationDbContext dbContext = GetDbContext();
+
+            var orderId = Guid.Parse("56c1f9c7-54a5-4f3d-b967-1f4073415d08");
+
+            var order = new Model.Order
+            {
+                Id = orderId,
+                Name = "Fred",
+                Address1 = "ad1",
+                Address2 = "ad2",
+                Town = "town",
+                Postcode = "pcode",
+                Phone = "1234",
+                Email = "fred@d.d",
+                DeliveryInstructions = "In the coal bunker",
+                OwnerId = Guid.Parse("9940c08a-34b5-4e42-a736-bf9aec716f09"),
+                CreatedAt = DateTime.Parse("08/18/2018 07:22:16")
+            };
+
+            var orderItem = new OrderItem
+            {
+                OrderId = orderId,
+                ItemId = Guid.Parse("600DCA30-C6E2-4035-AD15-783C122D6EA4"),
+                Quantity = 1,
+                Name = "Plate of sausages",
+                Description = "Big bowl of sausages"
+            };
+
+            await dbContext.Orders.AddAsync(order);
+            await dbContext.OrderItems.AddAsync(orderItem);
+            await dbContext.SaveChangesAsync();
+
+            return order;
+        }
+
+        [Fact]
+        public async Task Get_Order_For_Id()
+        {
+            Model.Order order = await CreateOrder();
+
+            IExecutionResult result = await ServiceProvider.ExecuteRequestAsync(
+                QueryRequestBuilder
+                    .New()
+                    .SetQuery(@"
+                        query OrderById($id:ID!) {
+	                        orderById(id: $id) {
+                            id
+                            name
+                            address1
+                            address2
+                            town
+                            postcode
+                            phone
+                            email
+                            deliveryInstructions
+                            items {
+                              itemId
+                              name
+                              description
+                              quantity
+                            }
+                          }
+                        }
+                    ")
+                    .SetVariableValue(name: "id", value: order.Id.ToString())
+                    .Create());
+
+            result.MatchSnapshot();
+        }
+    }
+}

--- a/GraphQL.Tests/Orders/__snapshots__/OrderQueriesTests.Get_Order_For_Id.snap
+++ b/GraphQL.Tests/Orders/__snapshots__/OrderQueriesTests.Get_Order_For_Id.snap
@@ -1,0 +1,29 @@
+﻿{
+  "Label": null,
+  "Path": null,
+  "Data": {
+    "orderById": {
+      "id": "56c1f9c7-54a5-4f3d-b967-1f4073415d08",
+      "name": "Fred",
+      "address1": "ad1",
+      "address2": "ad2",
+      "town": "town",
+      "postcode": "pcode",
+      "phone": "1234",
+      "email": "fred@d.d",
+      "deliveryInstructions": "In the coal bunker",
+      "items": [
+        {
+          "itemId": "600dca30-c6e2-4035-ad15-783c122d6ea4",
+          "name": "Plate of sausages",
+          "description": "Big bowl of sausages",
+          "quantity": 1
+        }
+      ]
+    }
+  },
+  "Errors": null,
+  "Extensions": null,
+  "ContextData": null,
+  "HasNext": null
+}

--- a/GraphQL/Migrations/20201227162129_Order.Designer.cs
+++ b/GraphQL/Migrations/20201227162129_Order.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WeDoTakeawayAPI.GraphQL.Model;
@@ -9,9 +10,10 @@ using WeDoTakeawayAPI.GraphQL.Model;
 namespace WeDoTakeawayAPI.GraphQL.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201227162129_Order")]
+    partial class Order
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GraphQL/Migrations/20201227162129_Order.cs
+++ b/GraphQL/Migrations/20201227162129_Order.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace WeDoTakeawayAPI.GraphQL.Migrations
+{
+    public partial class Order : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "order",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    address1 = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    address2 = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    town = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    postcode = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    phone = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    email = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    delivery_instructions = table.Column<string>(type: "text", nullable: false),
+                    created_at = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    owner_id = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_order", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "order_item",
+                columns: table => new
+                {
+                    item_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    order_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    description = table.Column<string>(type: "text", nullable: true),
+                    quantity = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_order_item", x => new { x.item_id, x.order_id });
+                    table.ForeignKey(
+                        name: "FK_order_item_item_item_id",
+                        column: x => x.item_id,
+                        principalTable: "item",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_order_item_order_order_id",
+                        column: x => x.order_id,
+                        principalTable: "order",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_order_owner_id",
+                table: "order",
+                column: "owner_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_order_item_order_id",
+                table: "order_item",
+                column: "order_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "order_item");
+
+            migrationBuilder.DropTable(
+                name: "order");
+        }
+    }
+}

--- a/GraphQL/Model/ApplicationDbContext.cs
+++ b/GraphQL/Model/ApplicationDbContext.cs
@@ -38,6 +38,15 @@ namespace WeDoTakeawayAPI.GraphQL.Model
                 .Entity<Basket>()
                 .HasIndex(b => b.OwnerId)
                 .IsUnique();
+
+            // Many-to-many: Order <-> Item
+            modelBuilder
+                .Entity<OrderItem>()
+                .HasKey(oi => new {oi.ItemId, oi.OrderId});
+
+            modelBuilder
+                .Entity<Order>()
+                .HasIndex(o => o.OwnerId);
         }
 
         public DbSet<Basket> Baskets { get; set; } = default!;
@@ -48,10 +57,16 @@ namespace WeDoTakeawayAPI.GraphQL.Model
 
         public DbSet<Item> Items { get; set; } = default!;
 
+        public DbSet<ItemIngredient> ItemIngredients { get; set; } = default!;
+
         public DbSet<Menu> Menus { get; set; } = default!;
+
+
+        public DbSet<Order> Orders { get; set; } = default!;
+
+        public DbSet<OrderItem> OrderItems { get; set; } = default!;
 
         public DbSet<Section> Sections { get; set; } = default!;
 
-        public DbSet<ItemIngredient> ItemIngredients { get; set; } = default!;
     }
 }

--- a/GraphQL/Model/Order.cs
+++ b/GraphQL/Model/Order.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace WeDoTakeawayAPI.GraphQL.Model
+{
+    [Table("order")]
+    public class Order
+    {
+        [Column("id")]
+        public Guid Id { get; set; }
+
+        [Required]
+        [Column("name")]
+        [StringLength(100)]
+        public string? Name { get; set; }
+
+        [Required]
+        [Column("address1")]
+        [StringLength(100)]
+        public string? Address1 { get; set; }
+
+        [Column("address2")]
+        [StringLength(100)]
+        public string? Address2 { get; set; }
+
+        [Required]
+        [Column("town")]
+        [StringLength(100)]
+        public string? Town { get; set; }
+
+        [Required]
+        [Column("postcode")]
+        [StringLength(8)]
+        public string? Postcode { get; set; }
+
+        [Required]
+        [Column("phone")]
+        [StringLength(20)]
+        public string? Phone { get; set; }
+
+        [Column("email")]
+        [StringLength(100)]
+        public string? Email { get; set; }
+
+        [Required]
+        [Column("delivery_instructions", TypeName = "text")]
+        public string? DeliveryInstructions { get; set; }
+
+        [Column("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [Required] [Column("owner_id")] public Guid OwnerId { get; set; }
+
+        public ICollection<OrderItem> OrderItems { get; set; } =
+            new List<OrderItem>();
+    }
+}

--- a/GraphQL/Model/OrderItem.cs
+++ b/GraphQL/Model/OrderItem.cs
@@ -1,0 +1,36 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using HotChocolate;
+
+namespace WeDoTakeawayAPI.GraphQL.Model
+{
+    [Table("order_item")]
+    public class OrderItem
+    {
+        [Required]
+        [Column("item_id")]
+        public Guid ItemId { get; set; }
+
+        public Item? Item { get; set; }
+
+        [Required]
+        [Column("order_id")]
+        [GraphQLIgnore]
+        public Guid OrderId { get; set; }
+
+        public Order? Order { get; set; }
+
+        [Required]
+        [Column("name")]
+        [StringLength(100)]
+        public string? Name { get; set; }
+
+        [Column("description")]
+        public string? Description { get; set; }
+
+        [Required]
+        [Column("quantity")]
+        public int Quantity { get; set; }
+    }
+}

--- a/GraphQL/Order/AddOrderInput.cs
+++ b/GraphQL/Order/AddOrderInput.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace WeDoTakeawayAPI.GraphQL.Order
+{
+    public record OrderItemInput(
+        Guid ItemId,
+        int Quantity
+    );
+
+    public record AddOrderInput(
+        string Name,
+        string Address1,
+        string? Address2,
+        string Town,
+        string Postcode,
+        string Phone,
+        string? Email,
+        string? DeliveryInstructions,
+        Guid OwnerId,
+        IEnumerable<OrderItemInput> Items
+    );
+}

--- a/GraphQL/Order/AddOrderMutation.cs
+++ b/GraphQL/Order/AddOrderMutation.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using HotChocolate;
+using HotChocolate.Types;
+using Microsoft.EntityFrameworkCore;
+using WeDoTakeawayAPI.GraphQL.Common;
+using WeDoTakeawayAPI.GraphQL.Extensions;
+using WeDoTakeawayAPI.GraphQL.Model;
+
+namespace WeDoTakeawayAPI.GraphQL.Order
+{
+    [ExtendObjectType(Name = "Mutation")]
+    public class AddOrderMutation
+    {
+        [UseApplicationDbContext]
+        public async Task<AddOrderPayload> AddOrderAsync(AddOrderInput input,
+            [ScopedService] ApplicationDbContext dbContext)
+        {
+            // Check that there are quantities
+            if (!input.Items.Any())
+            {
+                return new AddOrderPayload( new UserError("No items to order", "1010"));
+            }
+
+            // Check the quantities are valid
+            if (input.Items.Any(item => item.Quantity < 1 || item.Quantity > 99))
+            {
+                return new AddOrderPayload( new UserError("Invalid order item quantity", "1011"));
+            }
+
+            // Check that the items provided exist in the db
+            var itemIds = input.Items.Select(item => item.ItemId).ToList();
+            Model.Item[]? dbItems = await dbContext.Items
+                .Where(i => itemIds.Contains(i.Id)).ToArrayAsync();
+
+            if (dbItems.Length != input.Items.Count())
+            {
+                return new AddOrderPayload( new UserError("Invalid order item id", "1012"));
+            }
+
+            // Create the order object.
+            var orderId = Guid.NewGuid();
+            Model.Order order = new Model.Order
+            {
+                Id = orderId,
+                Name = input.Name,
+                Address1 = input.Address1,
+                Address2 = input.Address2,
+                Town = input.Town,
+                Postcode = input.Postcode,
+                Phone = input.Phone,
+                Email = input.Email,
+                DeliveryInstructions = input.DeliveryInstructions,
+                OwnerId = input.OwnerId,
+                CreatedAt = DateTime.Now
+            };
+
+            await dbContext.Orders.AddAsync(order);
+
+
+            IEnumerable<OrderItemInput> items = input.Items;
+
+            // Now add the order items
+            foreach ((Guid itemId, var quantity) in items)
+            {
+                // Get a snapshot of the item when ordered
+                Model.Item dbItem = dbItems.First(item => item.Id == itemId);
+
+                OrderItem orderItem = new OrderItem
+                {
+                    OrderId = orderId,
+                    ItemId = itemId,
+                    Quantity = quantity,
+                    Name = dbItem?.Name,
+                    Description = dbItem?.Description
+                };
+
+                await dbContext.OrderItems.AddAsync(orderItem);
+            }
+
+            await dbContext.SaveChangesAsync();
+            return new AddOrderPayload(order);
+        }
+    }
+}

--- a/GraphQL/Order/AddOrderPayload.cs
+++ b/GraphQL/Order/AddOrderPayload.cs
@@ -1,0 +1,20 @@
+using WeDoTakeawayAPI.GraphQL.Common;
+
+
+namespace WeDoTakeawayAPI.GraphQL.Order
+{
+    public class AddOrderPayload : Payload
+    {
+        public Model.Order? Order { get; }
+
+        public AddOrderPayload(Model.Order order)
+        {
+            Order = order;
+        }
+
+        public AddOrderPayload(UserError error)
+            : base(new[] { error })
+        {
+        }
+    }
+}

--- a/GraphQL/Order/OrderQueries.cs
+++ b/GraphQL/Order/OrderQueries.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HotChocolate;
+using HotChocolate.Types;
+using Microsoft.EntityFrameworkCore;
+using WeDoTakeawayAPI.GraphQL.Model;
+using WeDoTakeawayAPI.GraphQL.Extensions;
+
+namespace WeDoTakeawayAPI.GraphQL.Order
+{
+    [ExtendObjectType(Name = "Query")]
+    public class OrderQueries
+    {
+        [UseApplicationDbContext]
+        public async Task<Model.Order> GetOrderById(
+            Guid id,
+            [ScopedService] ApplicationDbContext dbContext,
+            CancellationToken cancellationToken)
+        {
+
+            Model.Order order = await dbContext.Orders
+                .Where(o => o.Id == id)
+                .Include(o => o.OrderItems)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return order;
+        }
+    }
+}

--- a/GraphQL/Order/OrderType.cs
+++ b/GraphQL/Order/OrderType.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HotChocolate;
+using HotChocolate.Types;
+using Microsoft.EntityFrameworkCore;
+using WeDoTakeawayAPI.GraphQL.Extensions;
+using WeDoTakeawayAPI.GraphQL.Model;
+
+namespace WeDoTakeawayAPI.GraphQL.Order
+{
+    public class OrderType : ObjectType<Model.Order>
+    {
+        protected override void Configure(IObjectTypeDescriptor<Model.Order> descriptor)
+        {
+            descriptor
+                .Field(o => o.OrderItems)
+                .ResolveWith<OrderResolvers>(t =>
+                    t.GetItemsAsync(
+                        default!,
+                        default!,
+                        default!
+                    )
+                )
+                .UseDbContext<ApplicationDbContext>()
+                .Name("items");
+        }
+
+        private class OrderResolvers
+        {
+
+            public async Task<IEnumerable<OrderItem>> GetItemsAsync(
+                Model.Order order,
+                [ScopedService] ApplicationDbContext dbContext,
+                CancellationToken cancellationToken)
+            {
+                // Get all the order item records for this order
+                OrderItem[]? orderItems = await dbContext.OrderItems
+                    .Where(oi => oi.OrderId == order.Id)
+                    .Include(bi => bi.Item)
+                    .ToArrayAsync(cancellationToken);
+
+                return orderItems;
+            }
+        }
+    }
+}

--- a/GraphQL/Startup.cs
+++ b/GraphQL/Startup.cs
@@ -13,6 +13,7 @@ using WeDoTakeawayAPI.GraphQL.Item;
 using WeDoTakeawayAPI.GraphQL.Menu;
 using WeDoTakeawayAPI.GraphQL.Menu.DataLoaders;
 using WeDoTakeawayAPI.GraphQL.Model;
+using WeDoTakeawayAPI.GraphQL.Order;
 using WeDoTakeawayAPI.GraphQL.Section;
 using WeDoTakeawayAPI.GraphQL.Section.DataLoaders;
 
@@ -40,15 +41,18 @@ namespace WeDoTakeawayAPI.GraphQL
                     .AddTypeExtension<BasketQueries>()
                     .AddTypeExtension<ItemQueries>()
                     .AddTypeExtension<MenuQueries>()
+                    .AddTypeExtension<OrderQueries>()
                     .AddTypeExtension<SectionQueries>()
                 .AddMutationType(d => d.Name("Mutation"))
                     .AddTypeExtension<AddBasketItemMutations>()
                     .AddTypeExtension<ClearBasketMutations>()
                     .AddTypeExtension<RemoveBasketItemMutations>()
                     .AddTypeExtension<UpdateBasketItemMutations>()
+                    .AddTypeExtension<AddOrderMutation>()
                 .AddType<BasketType>()
                 .AddType<ItemType>()
                 .AddType<MenuType>()
+                .AddType<OrderType>()
                 .AddType<SectionType>()
                 .AddDataLoader<IngredientByIdDataLoader>()
                 .AddDataLoader<ItemByIdDataLoader>()


### PR DESCRIPTION
Adds 'order' and 'item_item' to the database model, storing new orders and the items associated with them. The items added to the order include the item name and description, just in case the item name and description is changed after the order is posted so you know what they ordered at that point in time.

The addOrderMutation accepts the contact details, instructions and items as well as the owner id for the client. Later that will become the customer id.

Items are verified to ensure valid item id's are provided and the quantities are ok. Also checks for orders for no items.

<img width="1061" alt="Screenshot 2020-12-27 at 18 10 11" src="https://user-images.githubusercontent.com/56056/103177081-31dbf300-486f-11eb-8949-0d47f0bb338f.png">

<img width="1235" alt="Screenshot 2020-12-27 at 18 11 20" src="https://user-images.githubusercontent.com/56056/103177083-33a5b680-486f-11eb-8cb8-2274cd9fa3c3.png">

<img width="1235" alt="Screenshot 2020-12-27 at 18 11 33" src="https://user-images.githubusercontent.com/56056/103177085-33a5b680-486f-11eb-9541-dc245b686280.png">
