### PR TITLE
Update schema to make basket items and item ingredients/section non-null

### DIFF
--- a/GraphQL.Tests/__snapshots__/WeDoTakeawayApiSchemaTests.Verify_Schema.snap
+++ b/GraphQL.Tests/__snapshots__/WeDoTakeawayApiSchemaTests.Verify_Schema.snap
@@ -4,7 +4,7 @@
 }
 
 type Basket {
-  items: [BasketItem]
+  items: [BasketItem!]!
   id: ID!
   ownerId: ID!
   basketType: BasketTypes!
@@ -19,8 +19,8 @@ type BasketItem {
 }
 
 type Item {
-  sections: [Section]
-  ingredients: [ItemIngredient]
+  sections: [Section!]!
+  ingredients: [ItemIngredient!]!
   id: ID!
   name: String!
   description: String

--- a/GraphQL/Basket/BasketItemExpanded.cs
+++ b/GraphQL/Basket/BasketItemExpanded.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using HotChocolate;
+using HotChocolate.Types;
 
 namespace WeDoTakeawayAPI.GraphQL.Basket
 {
@@ -31,5 +32,10 @@ namespace WeDoTakeawayAPI.GraphQL.Basket
         public string? Photo { get; set; }
 
         public int? Quantity { get; }
+    }
+
+    public class BasketItemExpandedType : ObjectType<BasketItemExpanded>
+    {
+
     }
 }

--- a/GraphQL/Basket/BasketType.cs
+++ b/GraphQL/Basket/BasketType.cs
@@ -18,6 +18,7 @@ namespace WeDoTakeawayAPI.GraphQL.Basket
         {
             descriptor
                 .Field(b => b.BasketItems)
+                .Type<NonNullType<ListType<NonNullType<BasketItemExpandedType>>>>()
                 .ResolveWith<BasketResolvers>(t =>
                     t.GetItemsAsync(
                         default!,
@@ -26,7 +27,8 @@ namespace WeDoTakeawayAPI.GraphQL.Basket
                     )
                 )
                 .UseDbContext<ApplicationDbContext>()
-                .Name("items");
+                .Name("items")
+                ;
         }
 
         private class BasketResolvers
@@ -38,7 +40,7 @@ namespace WeDoTakeawayAPI.GraphQL.Basket
                 CancellationToken cancellationToken)
             {
                 // Get all the basketitem records and their associated item records for this basket
-                var basketItems = await dbContext.BasketItems
+                BasketItem[] basketItems = await dbContext.BasketItems
                     .Where(bi => bi.BasketId == basket.Id)
                     .Include(bi => bi.Item)
                     .ToArrayAsync(cancellationToken);

--- a/GraphQL/Ingredient/IngredientType.cs
+++ b/GraphQL/Ingredient/IngredientType.cs
@@ -1,0 +1,8 @@
+using HotChocolate.Types;
+
+namespace WeDoTakeawayAPI.GraphQL.Ingredient
+{
+    public class IngredientType : ObjectType<Model.Ingredient>
+    {
+    }
+}

--- a/GraphQL/Ingredient/ItemIngredientWithQuantity.cs
+++ b/GraphQL/Ingredient/ItemIngredientWithQuantity.cs
@@ -1,5 +1,6 @@
 using System;
 using HotChocolate;
+using HotChocolate.Types;
 
 namespace WeDoTakeawayAPI.GraphQL.Ingredient
 {
@@ -27,5 +28,9 @@ namespace WeDoTakeawayAPI.GraphQL.Ingredient
         public string? Description { get; }
         public string? Photo { get; }
         public int? Quantity { get; }
+    }
+
+    public class ItemIngredientWithQuantityType : ObjectType<ItemIngredientWithQuantity>
+    {
     }
 }


### PR DESCRIPTION
The basket items property should be a non-nullable array. It always return an array, even when it is empty, and this needed to be reflected in the schema.